### PR TITLE
Removed fails_with llvm as that is deprecated.

### DIFF
--- a/llvm-mesos.rb
+++ b/llvm-mesos.rb
@@ -31,7 +31,6 @@ class LlvmMesos < Formula
 
   # Apple's libstdc++ is too old to build LLVM
   fails_with :gcc
-  fails_with :llvm
 
   def install
     # Apple's libstdc++ is too old to build LLVM


### PR DESCRIPTION
Other projects also simply remove this failure check and thus the warning disappears.

Examples:
gRPC https://github.com/grpc/homebrew-grpc/pull/105/commits/fb0e9d98667549e100f17f947cbab4160d889121
kong https://github.com/Mashape/homebrew-kong/commit/d26bf4aa175cdf6b2e3242e6e7ea5aac34b6f9d0